### PR TITLE
Add waiting for feedback during activation step

### DIFF
--- a/include/rosbot_hardware_interfaces/rosbot_imu_sensor.hpp
+++ b/include/rosbot_hardware_interfaces/rosbot_imu_sensor.hpp
@@ -63,6 +63,9 @@ protected:
   void imu_cb(const std::shared_ptr<Imu> msg);
   rclcpp::executors::MultiThreadedExecutor executor_;
   std::unique_ptr<std::thread> executor_thread_;
+
+  uint connection_check_period_ms_;
+  uint connection_timeout_ms_;
 };
 
 }  // namespace rosbot_hardware_interfaces

--- a/include/rosbot_hardware_interfaces/rosbot_system.hpp
+++ b/include/rosbot_hardware_interfaces/rosbot_system.hpp
@@ -89,6 +89,9 @@ protected:
 
   double wheel_radius_;
   std::vector<std::string> velocity_command_joint_order_;
+
+  uint connection_check_period_ms_;
+  uint connection_timeout_ms_;
 };
 
 }  // namespace rosbot_hardware_interfaces

--- a/urdf/ros2_control.urdf.xacro
+++ b/urdf/ros2_control.urdf.xacro
@@ -4,6 +4,8 @@
         <ros2_control name="imu" type="sensor">
             <hardware>
                 <plugin>rosbot_hardware_interfaces/RosbotImuSensor</plugin>
+                <param name="connection_timeout_ms">120000</param>
+                <param name="connection_check_period_ms">500</param>
             </hardware>
             <sensor name="imu">
                 <state_interface name="orientation.x" />
@@ -22,6 +24,8 @@
         <ros2_control name="wheels" type="system">
             <hardware>
                 <plugin>rosbot_hardware_interfaces/RosbotSystem</plugin>
+                <param name="connection_timeout_ms">120000</param>
+                <param name="connection_check_period_ms">500</param>
             </hardware>
 
             <joint name="front_left_wheel_joint">


### PR DESCRIPTION
Previously in activation step only 0 were assigned which resulted in publishing 0 values before establishing connection with microros. I think that activating after receiving first message will be better.