### PR TITLE
Refactor lifecycle transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Rosbots contain [micro-ros](https://micro.ros.org/) firmware which provides the 
 ### Subscribes
 
 - `/cmd_vel` (*geometry_msgs/Twist*, **/rosbot_base_controller**)
-- `/_motors_response` (*sensor_msgs/msg/JointState*, **/hardware_node**)
+- `/_motors_response` (*sensor_msgs/msg/JointState*, **/rosbot_system_node**)
 - `/_imu/data_raw` (*sensor_msgs/msg/Imu*, **/imu_sensor_node**)
 
 ### Publishes
 - `/imu_broadcaster/imu` (*sensor_msgs/Imu*, **/imu_broadcaster**)
 - `/rosbot_base_controller/odom` (*nav_msgs/Odometry*, **/rosbot_base_controller**)
-- `/_motors_cmd` (*std_msgs/msg/Float32MultiArray*, **/hardware_node**)
+- `/_motors_cmd` (*std_msgs/msg/Float32MultiArray*, **/rosbot_system_node**)
 
 # Usage
 1. Add this repository to ros2 workspace

--- a/config/example_diff_drive_controller.yaml
+++ b/config/example_diff_drive_controller.yaml
@@ -14,22 +14,6 @@ imu_broadcaster:
     sensor_name: "imu"
     frame_id: "imu"
 
-hardware_node:
-  ros__parameters:
-    # for some reason diff drive controller publishes velocities for motors in rad/s, but expects feedback in m/s
-    # both commands and feedback from digital board are in rad/s, so it is necessary to convert it
-    # maybe will be resolved (https://github.com/ros-controls/ros2_controllers/issues/411), then it can be removed
-    wheel_radius: 0.048
-
-    # order of velocity commands to be published in motors_cmd Float32MultiArray msg
-    velocity_command_joint_order:
-      [
-        "rear_right_wheel_joint",
-        "rear_left_wheel_joint",
-        "front_right_wheel_joint",
-        "front_left_wheel_joint",
-      ]
-
 rosbot_base_controller:
   ros__parameters:
     left_wheel_names: ["front_left_wheel_joint", "rear_left_wheel_joint"]

--- a/include/rosbot_hardware_interfaces/rosbot_imu_sensor.hpp
+++ b/include/rosbot_hardware_interfaces/rosbot_imu_sensor.hpp
@@ -38,10 +38,19 @@ public:
   CallbackReturn on_configure(const rclcpp_lifecycle::State& previous_state) override;
 
   ROSBOT_HARDWARE_INTERFACES_PUBLIC
+  CallbackReturn on_cleanup(const rclcpp_lifecycle::State& previous_state) override;
+
+  ROSBOT_HARDWARE_INTERFACES_PUBLIC
   CallbackReturn on_activate(const rclcpp_lifecycle::State& previous_state) override;
 
   ROSBOT_HARDWARE_INTERFACES_PUBLIC
   CallbackReturn on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
+
+  ROSBOT_HARDWARE_INTERFACES_PUBLIC
+  CallbackReturn on_shutdown(const rclcpp_lifecycle::State& previous_state) override;
+
+  ROSBOT_HARDWARE_INTERFACES_PUBLIC
+  CallbackReturn on_error(const rclcpp_lifecycle::State& previous_state) override;
 
   ROSBOT_HARDWARE_INTERFACES_PUBLIC
   std::vector<StateInterface> export_state_interfaces() override;
@@ -50,6 +59,8 @@ public:
   return_type read(const rclcpp::Time& time, const rclcpp::Duration& period) override;
 
 protected:
+  void cleanup_node();
+
   realtime_tools::RealtimeBox<std::shared_ptr<Imu>> received_imu_msg_ptr_{ nullptr };
 
   rclcpp::Subscription<Imu>::SharedPtr imu_subscriber_ = nullptr;

--- a/include/rosbot_hardware_interfaces/rosbot_system.hpp
+++ b/include/rosbot_hardware_interfaces/rosbot_system.hpp
@@ -34,16 +34,13 @@ public:
   RCLCPP_SHARED_PTR_DEFINITIONS(RosbotSystem)
 
   ROSBOT_HARDWARE_INTERFACES_PUBLIC
-  std::vector<StateInterface> export_state_interfaces() override;
-
-  ROSBOT_HARDWARE_INTERFACES_PUBLIC
-  std::vector<CommandInterface> export_command_interfaces() override;
-
-  ROSBOT_HARDWARE_INTERFACES_PUBLIC
   CallbackReturn on_init(const hardware_interface::HardwareInfo& hardware_info) override;
 
   ROSBOT_HARDWARE_INTERFACES_PUBLIC
   CallbackReturn on_configure(const rclcpp_lifecycle::State& previous_state) override;
+
+  ROSBOT_HARDWARE_INTERFACES_PUBLIC
+  CallbackReturn on_cleanup(const rclcpp_lifecycle::State& previous_state) override;
 
   ROSBOT_HARDWARE_INTERFACES_PUBLIC
   CallbackReturn on_activate(const rclcpp_lifecycle::State& previous_state) override;
@@ -52,13 +49,16 @@ public:
   CallbackReturn on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
 
   ROSBOT_HARDWARE_INTERFACES_PUBLIC
-  CallbackReturn on_cleanup(const rclcpp_lifecycle::State& previous_state) override;
-
-  ROSBOT_HARDWARE_INTERFACES_PUBLIC
   CallbackReturn on_shutdown(const rclcpp_lifecycle::State& previous_state) override;
 
   ROSBOT_HARDWARE_INTERFACES_PUBLIC
   CallbackReturn on_error(const rclcpp_lifecycle::State& previous_state) override;
+
+  ROSBOT_HARDWARE_INTERFACES_PUBLIC
+  std::vector<StateInterface> export_state_interfaces() override;
+
+  ROSBOT_HARDWARE_INTERFACES_PUBLIC
+  std::vector<CommandInterface> export_command_interfaces() override;
 
   ROSBOT_HARDWARE_INTERFACES_PUBLIC
   return_type read(const rclcpp::Time& time, const rclcpp::Duration& period) override;
@@ -67,6 +67,8 @@ public:
   return_type write(const rclcpp::Time& time, const rclcpp::Duration& period) override;
 
 protected:
+  void cleanup_node();
+
   realtime_tools::RealtimeBox<std::shared_ptr<JointState>> received_motor_state_msg_ptr_{ nullptr };
 
   std::shared_ptr<rclcpp::Publisher<Float32MultiArray>> motor_command_publisher_ = nullptr;

--- a/src/rosbot_imu_sensor.cpp
+++ b/src/rosbot_imu_sensor.cpp
@@ -11,6 +11,8 @@ namespace rosbot_hardware_interfaces
 {
 CallbackReturn RosbotImuSensor::on_init(const hardware_interface::HardwareInfo& hardware_info)
 {
+  RCLCPP_INFO(rclcpp::get_logger("RosbotImuSensor"), "Initializing");
+
   if (hardware_interface::SensorInterface::on_init(hardware_info) != CallbackReturn::SUCCESS)
   {
     return CallbackReturn::ERROR;
@@ -26,7 +28,7 @@ CallbackReturn RosbotImuSensor::on_init(const hardware_interface::HardwareInfo& 
 
 CallbackReturn RosbotImuSensor::on_configure(const rclcpp_lifecycle::State&)
 {
-  RCLCPP_INFO(rclcpp::get_logger("RosbotImuSensor"), "Configuring...");
+  RCLCPP_INFO(rclcpp::get_logger("RosbotImuSensor"), "Configuring");
 
   received_imu_msg_ptr_.set(nullptr);
 
@@ -39,18 +41,20 @@ CallbackReturn RosbotImuSensor::on_configure(const rclcpp_lifecycle::State&)
   executor_thread_ =
       std::make_unique<std::thread>(std::bind(&rclcpp::executors::MultiThreadedExecutor::spin, &executor_));
 
-  RCLCPP_INFO(rclcpp::get_logger("RosbotImuSensor"), "Successfully configured");
   return CallbackReturn::SUCCESS;
 }
 
 CallbackReturn RosbotImuSensor::on_cleanup(const rclcpp_lifecycle::State&)
 {
+  RCLCPP_INFO(rclcpp::get_logger("RosbotImuSensor"), "Cleaning up");
   cleanup_node();
   return CallbackReturn::SUCCESS;
 }
 
 CallbackReturn RosbotImuSensor::on_activate(const rclcpp_lifecycle::State&)
 {
+  RCLCPP_INFO(rclcpp::get_logger("RosbotImuSensor"), "Activating");
+
   std::shared_ptr<Imu> imu_msg;
   for (uint wait_time = 0; wait_time <= connection_timeout_ms_; wait_time += connection_check_period_ms_)
   {
@@ -71,18 +75,21 @@ CallbackReturn RosbotImuSensor::on_activate(const rclcpp_lifecycle::State&)
 
 CallbackReturn RosbotImuSensor::on_deactivate(const rclcpp_lifecycle::State&)
 {
+  RCLCPP_INFO(rclcpp::get_logger("RosbotImuSensor"), "Deactivating");
   received_imu_msg_ptr_.set(nullptr);
   return CallbackReturn::SUCCESS;
 }
 
 CallbackReturn RosbotImuSensor::on_shutdown(const rclcpp_lifecycle::State&)
 {
+  RCLCPP_INFO(rclcpp::get_logger("RosbotImuSensor"), "Shutting down");
   cleanup_node();
   return CallbackReturn::SUCCESS;
 }
 
 CallbackReturn RosbotImuSensor::on_error(const rclcpp_lifecycle::State&)
 {
+  RCLCPP_INFO(rclcpp::get_logger("RosbotImuSensor"), "Handling error");
   cleanup_node();
   return CallbackReturn::SUCCESS;
 }

--- a/src/rosbot_imu_sensor.cpp
+++ b/src/rosbot_imu_sensor.cpp
@@ -28,6 +28,8 @@ CallbackReturn RosbotImuSensor::on_configure(const rclcpp_lifecycle::State&)
 {
   RCLCPP_INFO(rclcpp::get_logger("RosbotImuSensor"), "Configuring...");
 
+  received_imu_msg_ptr_.set(nullptr);
+
   node_ = std::make_shared<rclcpp::Node>("imu_sensor_node");
 
   imu_subscriber_ = node_->create_subscription<Imu>("~/imu", rclcpp::SensorDataQoS(),
@@ -69,6 +71,7 @@ CallbackReturn RosbotImuSensor::on_activate(const rclcpp_lifecycle::State&)
 
 CallbackReturn RosbotImuSensor::on_deactivate(const rclcpp_lifecycle::State&)
 {
+  received_imu_msg_ptr_.set(nullptr);
   return CallbackReturn::SUCCESS;
 }
 

--- a/src/rosbot_system.cpp
+++ b/src/rosbot_system.cpp
@@ -105,6 +105,8 @@ CallbackReturn RosbotSystem::on_configure(const rclcpp_lifecycle::State&)
 {
   RCLCPP_INFO(rclcpp::get_logger("RosbotSystem"), "Configuring...");
 
+  received_motor_state_msg_ptr_.set(nullptr);
+
   node_ = std::make_shared<rclcpp::Node>("rosbot_system_node");
 
   motor_command_publisher_ = node_->create_publisher<Float32MultiArray>("~/motors_cmd", rclcpp::SensorDataQoS());
@@ -152,6 +154,7 @@ CallbackReturn RosbotSystem::on_activate(const rclcpp_lifecycle::State&)
 
 CallbackReturn RosbotSystem::on_deactivate(const rclcpp_lifecycle::State&)
 {
+  received_motor_state_msg_ptr_.set(nullptr);
   return CallbackReturn::SUCCESS;
 }
 

--- a/src/rosbot_system.cpp
+++ b/src/rosbot_system.cpp
@@ -12,6 +12,8 @@ namespace rosbot_hardware_interfaces
 {
 CallbackReturn RosbotSystem::on_init(const hardware_interface::HardwareInfo& hardware_info)
 {
+  RCLCPP_INFO(rclcpp::get_logger("RosbotSystem"), "Initializing");
+
   if (hardware_interface::SystemInterface::on_init(hardware_info) != CallbackReturn::SUCCESS)
   {
     return CallbackReturn::ERROR;
@@ -103,7 +105,7 @@ CallbackReturn RosbotSystem::on_init(const hardware_interface::HardwareInfo& har
 
 CallbackReturn RosbotSystem::on_configure(const rclcpp_lifecycle::State&)
 {
-  RCLCPP_INFO(rclcpp::get_logger("RosbotSystem"), "Configuring...");
+  RCLCPP_INFO(rclcpp::get_logger("RosbotSystem"), "Configuring");
 
   received_motor_state_msg_ptr_.set(nullptr);
 
@@ -117,8 +119,6 @@ CallbackReturn RosbotSystem::on_configure(const rclcpp_lifecycle::State&)
       node_->create_subscription<JointState>("~/motors_response", rclcpp::SensorDataQoS(),
                                              std::bind(&RosbotSystem::motor_state_cb, this, std::placeholders::_1));
 
-  RCLCPP_INFO(rclcpp::get_logger("RosbotSystem"), "Successfully configured");
-
   executor_.add_node(node_);
   executor_thread_ =
       std::make_unique<std::thread>(std::bind(&rclcpp::executors::MultiThreadedExecutor::spin, &executor_));
@@ -128,12 +128,16 @@ CallbackReturn RosbotSystem::on_configure(const rclcpp_lifecycle::State&)
 
 CallbackReturn RosbotSystem::on_cleanup(const rclcpp_lifecycle::State&)
 {
+  RCLCPP_INFO(rclcpp::get_logger("RosbotSystem"), "Cleaning up");
+
   cleanup_node();
   return CallbackReturn::SUCCESS;
 }
 
 CallbackReturn RosbotSystem::on_activate(const rclcpp_lifecycle::State&)
 {
+  RCLCPP_INFO(rclcpp::get_logger("RosbotSystem"), "Activating");
+
   std::shared_ptr<JointState> motor_state;
   for (uint wait_time = 0; wait_time <= connection_timeout_ms_; wait_time += connection_check_period_ms_)
   {
@@ -154,18 +158,21 @@ CallbackReturn RosbotSystem::on_activate(const rclcpp_lifecycle::State&)
 
 CallbackReturn RosbotSystem::on_deactivate(const rclcpp_lifecycle::State&)
 {
+  RCLCPP_INFO(rclcpp::get_logger("RosbotSystem"), "Deactivating");
   received_motor_state_msg_ptr_.set(nullptr);
   return CallbackReturn::SUCCESS;
 }
 
 CallbackReturn RosbotSystem::on_shutdown(const rclcpp_lifecycle::State&)
 {
+  RCLCPP_INFO(rclcpp::get_logger("RosbotSystem"), "Shutting down");
   cleanup_node();
   return CallbackReturn::SUCCESS;
 }
 
 CallbackReturn RosbotSystem::on_error(const rclcpp_lifecycle::State&)
 {
+  RCLCPP_INFO(rclcpp::get_logger("RosbotSystem"), "Handling error");
   cleanup_node();
   return CallbackReturn::SUCCESS;
 }

--- a/urdf/ros2_control.urdf.xacro
+++ b/urdf/ros2_control.urdf.xacro
@@ -26,6 +26,19 @@
                 <plugin>rosbot_hardware_interfaces/RosbotSystem</plugin>
                 <param name="connection_timeout_ms">120000</param>
                 <param name="connection_check_period_ms">500</param>
+
+                <!-- for some reason diff drive controller publishes velocities for motors in rad/s, but expects feedback in m/s
+                both commands and feedback from digital board are in rad/s, so it is necessary to convert it
+                maybe will be resolved (https://github.com/ros-controls/ros2_controllers/issues/411), then it can be removed -->
+                <param name="wheel_radius">0.048</param>
+
+                <!-- order of velocity commands to be published in motors_cmd Float32MultiArray msg -->
+                <param name="velocity_command_joint_order">
+                    rear_right_wheel_joint,
+                    rear_left_wheel_joint,
+                    front_right_wheel_joint,
+                    front_left_wheel_joint
+                </param>
             </hardware>
 
             <joint name="front_left_wheel_joint">


### PR DESCRIPTION
Changes init/configure/activate so that it should be possible to dynamically make transitions. I tested changing to active/inactive state, but I wasn't able to find anything more practical and I'm still not totally sure that it is the best solution, but at least changing states no longer crashes node.

Additionally ros parameters were moved to ros2 control parameters.