### PR TITLE
Change velocity feedback units to rad/s

### DIFF
--- a/include/rosbot_hardware_interfaces/rosbot_system.hpp
+++ b/include/rosbot_hardware_interfaces/rosbot_system.hpp
@@ -89,7 +89,6 @@ protected:
   rclcpp::executors::MultiThreadedExecutor executor_;
   std::unique_ptr<std::thread> executor_thread_;
 
-  double wheel_radius_;
   std::vector<std::string> velocity_command_joint_order_;
 
   uint connection_check_period_ms_;

--- a/src/rosbot_system.cpp
+++ b/src/rosbot_system.cpp
@@ -68,7 +68,6 @@ CallbackReturn RosbotSystem::on_init(const hardware_interface::HardwareInfo& har
 
   connection_timeout_ms_ = std::stoul(info_.hardware_parameters["connection_timeout_ms"]);
   connection_check_period_ms_ = std::stoul(info_.hardware_parameters["connection_check_period_ms"]);
-  wheel_radius_ = std::stod(info_.hardware_parameters["wheel_radius"]);
 
   std::string velocity_command_joint_order_raw = info_.hardware_parameters["velocity_command_joint_order"];
   // remove whitespaces
@@ -242,7 +241,7 @@ return_type RosbotSystem::read(const rclcpp::Time&, const rclcpp::Duration&)
     }
 
     pos_state_[motor_state->name[i]] = motor_state->position[i];
-    vel_state_[motor_state->name[i]] = motor_state->velocity[i] * wheel_radius_;
+    vel_state_[motor_state->name[i]] = motor_state->velocity[i];
 
     RCLCPP_DEBUG(rclcpp::get_logger("RosbotSystem"), "Position feedback: %f, velocity feedback: %f",
                  pos_state_[motor_state->name[i]], vel_state_[motor_state->name[i]]);

--- a/urdf/ros2_control.urdf.xacro
+++ b/urdf/ros2_control.urdf.xacro
@@ -27,11 +27,6 @@
                 <param name="connection_timeout_ms">120000</param>
                 <param name="connection_check_period_ms">500</param>
 
-                <!-- for some reason diff drive controller publishes velocities for motors in rad/s, but expects feedback in m/s
-                both commands and feedback from digital board are in rad/s, so it is necessary to convert it
-                maybe will be resolved (https://github.com/ros-controls/ros2_controllers/issues/411), then it can be removed -->
-                <param name="wheel_radius">0.048</param>
-
                 <!-- order of velocity commands to be published in motors_cmd Float32MultiArray msg -->
                 <param name="velocity_command_joint_order">
                     rear_right_wheel_joint,


### PR DESCRIPTION
After recent fix in diff drive controller (version 2.15.0) it is no longer necessary to change to m/s